### PR TITLE
show executor's public hostname in description

### DIFF
--- a/cloudformation/userdata.sh
+++ b/cloudformation/userdata.sh
@@ -80,6 +80,7 @@ java -jar \$HOME/swarm-client.jar \
 -labels docker -labels $node_name \
 -master https://jenkins.conjur.net \
 -name $node_name -mode exclusive \
+-description '$(curl -s http://169.254.169.254/latest/meta-data/public-hostname)' \
 -username slaves -password $(conjur variable value jenkins/swarm/password) &
 "
 


### PR DESCRIPTION
This gets rid of a few steps when trying to SSH to an executor.
